### PR TITLE
Add an Ubuntu LAMP Drupal state.

### DIFF
--- a/small/apache/init.sls
+++ b/small/apache/init.sls
@@ -2,6 +2,8 @@ apache:
   pkg:
     {% if grains['os'] == 'RedHat' %}
     - name: httpd
+    {% else if grains['os'] == 'Ubuntu' %}
+    - name: apache2
     {% endif %}
     - installed
   service:

--- a/small/lamp-drupal/init.sls
+++ b/small/lamp-drupal/init.sls
@@ -1,0 +1,57 @@
+{% if grains['os'] == 'Ubuntu' %}
+
+php5:
+  pkg:
+    - installed
+
+php5-mysql:
+  pkg:
+    - installed
+
+php5-curl:
+  pkg:
+    - installed
+
+php5-cli:
+  pkg:
+    - installed
+
+php5-cgi:
+  pkg:
+    - installed
+
+php5-dev:
+  pkg:
+    - installed
+
+php-pear:
+  pkg:
+    - installed
+
+apache2:
+  pkg:
+    - installed
+
+pear-drush:
+  cmd.run:
+    - name: pear channel-discover pear.drush.org & pear install drush/drush
+
+mariadb-server-5.5:
+  cmd.run:
+    - name: sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
+    - unless: apt-key list | grep -q 0xcbcb082a1bb943db
+  file:
+    - append
+    - name: /etc/apt/sources.list
+    - text: deb http://ftp.osuosl.org/pub/mariadb/repo/5.5/ubuntu precise main
+    - skip_verify: True
+  cmd.run:
+    - name: sudo apt-get update
+  pkg:
+    - installed
+
+git:
+  pkg:
+    - installed
+
+{% endif %}


### PR DESCRIPTION
There might be a better way to do this:

pear-drush:
  cmd.run:
    - name: pear channel-discover pear.drush.org & pear install drush/drush

If drush is already installed, pear returns an error.

I updated the apache state that Thomas had as well with support for Ubuntu.

How can I handle the name here:

service:
    - name: httpd
    - running

as well to support ubuntu?
