### PR TITLE
update debian package names for vim init and absent

### DIFF
--- a/vim/absent.sls
+++ b/vim/absent.sls
@@ -3,6 +3,8 @@ vim:
   pkg:
     {% if grains['os'] == 'CentOS' or grains['os'] == 'Fedora' %}
     - name: vim-enhanced
+    {% elif grains['os'] == 'Debian' %}
+    - name: vim-runtime
     {% endif %}
     - purged
 

--- a/vim/init.sls
+++ b/vim/init.sls
@@ -4,7 +4,7 @@ vim:
     {% if grains['os_family'] == 'RedHat' %}
     - name: vim-enhanced
     {% elif grains['os'] == 'Debian' %}
-    - name: vim-rt
+    - name: vim-nox
     {% endif %}
 
 {% if grains['os'] == 'Arch'%}


### PR DESCRIPTION
The package "vim-rt" hasn't been in debian since potato, circa 2002.
