### PR TITLE
use grains['osrelease'] to decide wich EPEL package to install

### DIFF
--- a/epel.sls
+++ b/epel.sls
@@ -1,6 +1,10 @@
 epel:
     cmd:
         - run
-        - name: rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-7.noarch.rpm
-        - unless: test -e /etc/yum.repos.d/epel-testing.repo
+        {% if grains['osrelease'].startswith('5') %}
+        - name: rpm -Uvh http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm
+        {% elif grains['osrelease'].startswith('6') %}
+        - name: rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+        {% endif %}
+        - unless: test -e /etc/yum.repos.d/epel.repo
 


### PR DESCRIPTION
Both RHEL 6.x and 5.x are supported versions.  I just had to figure out how to compare only the first number in the osrelease grain, and thought I would share my finding to help others. 
