### PR TITLE
Allow salt-state ceph.eval to succeed with 0.17.1

### DIFF
--- a/ceph/apt.list
+++ b/ceph/apt.list
@@ -1,1 +1,1 @@
-deb http://ceph.com/debian/ {{ grains['lsb_codename'] }} main
+deb http://ceph.com/debian/ {{ grains['lsb_distrib_codename'] }} main

--- a/ceph/eval.conf
+++ b/ceph/eval.conf
@@ -36,7 +36,7 @@
 [mon.a]
 
 	host = {{ grains['localhost'] }}
-	mon addr = {{ salt['network.ip_addrs']('include_loopback=True')[-1] }}:6789
+	mon addr = {{ grains.get['fqdn_ip4'][-1] }}:6789
 
 [osd.0]
 	#host = {hostname}

--- a/ceph/eval.conf
+++ b/ceph/eval.conf
@@ -36,7 +36,7 @@
 [mon.a]
 
 	host = {{ grains['localhost'] }}
-	mon addr = {{ grains.get['fqdn_ip4'][-1] }}:6789
+	mon addr = {{ grains['fqdn_ip4'][-1] }}:6789
 
 [osd.0]
 	#host = {hostname}

--- a/ceph/eval.sls
+++ b/ceph/eval.sls
@@ -9,7 +9,7 @@ ceph:
     - dead
     - enable: False
     - require:
-      - file: /etc/eval.conf
+      - file: /etc/ceph/ceph.conf
    {% if grains['os'] == 'Ubuntu'%}
       - file: /etc/apt/sources.list.d/ceph.list
    {% endif %}


### PR DESCRIPTION
This PR fixes three issues with the existing ceph.eval state, which combined are require for the state to succeed with 0.17.1:
1. Fixes the name of the distrib codename grain referenced in apt.list.
2. Fixes the ip address lookup in the ceph.conf file.
3. Fixes the ceph state to correctly require the correct local filename of the ceph conf file.
